### PR TITLE
add pharm1 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ ENTRYPOINT java -Xmx1G -Xshareclasses -Xquickstart -jar /app.jar
 
 
 # export PROJECT_ID="$(gcloud config get-value project -q)"
-# docker build -t eu.gcr.io/${PROJECT_ID}/mag:v013 .
-# docker push eu.gcr.io/${PROJECT_ID}/mag:v013
-# docker run -d --name mag  -p 9090:9090 --memory="5G" --cpus="1" eu.gcr.io/fhir-ch/mag:v013
+# docker build -t eu.gcr.io/${PROJECT_ID}/mag:v016 .
+# docker push eu.gcr.io/${PROJECT_ID}/mag:v016
+# docker run -d --name mag  -p 9090:9090 --memory="5G" --cpus="1" eu.gcr.io/fhir-ch/mag:v016

--- a/client.http
+++ b/client.http
@@ -1,9 +1,9 @@
 ### RESTClient VSCode scripts
 ### Note ipf with a spring boot version has as default a fhir prefix, the ipf-tutorials-fhir is without the fhir prefix, iti-65 needs the camel servlet (different prefix camel)
 
-@host = http://localhost:9090/fhir
+### @host = http://localhost:9090/fhir
 
-### @host = http://test.ahdis.ch/fhir
+@host = http://test.ahdis.ch/fhir
 
 GET {{host}}/metadata HTTP/1.1
 Accept: application/fhir+json
@@ -22,7 +22,7 @@ Accept: application/fhir+json
 Content-Type: application/fhir+json
 
 ### Find Document Manifest XDSTools7 ahdis
-GET {{host}}/DocumentManifest/1.3.6.1.4.1.12559.11.13.2.6.3000 HTTP/1.1
+GET {{host}}/DocumentManifest/1.3.6.1.4.1.12559.11.13.2.6.3000.3 HTTP/1.1
 Accept: application/fhir+json
 Content-Type: application/fhir+json
 
@@ -32,13 +32,13 @@ Accept: application/fhir+json
 Content-Type: application/fhir+json
 
 ### Document References XDSTools7 ahdis
-GET {{host}}/DocumentReference/2.25.194845134685217374679299436971670498973 HTTP/1.1
+GET {{host}}/DocumentReference/1.3.6.1.4.1.12559.11.13.2.1.3000.3 HTTP/1.1
 Accept: application/fhir+json
 Content-Type: application/fhir+json
 
 
 ### ITI-68 Retrieve Document call
-GET http://localhost:9090/camel/xdsretrieve?uniqueId=2.25.194845134685217374679299436971670498973&repositoryUniqueId=1.1.4567332.1.2
+GET http://test.ahdis.ch/camel/xdsretrieve?uniqueId=1.3.6.1.4.1.12559.11.13.2.1.3000.3&repositoryUniqueId=1.1.4567332.1.2
 Accept: application/fhir+jsonn
 
 ### ITI-83 pixm call to https://ehealthsuisse.ihe-europe.net/PatientManager/patient/allPatients.seam?date=ANY|1597321706550|1597321706550&testData=false

--- a/pom.xml
+++ b/pom.xml
@@ -96,12 +96,12 @@
 		<dependency>
 			<groupId>org.openehealth.ipf.boot</groupId>
 			<artifactId>ipf-fhir-r4-spring-boot-starter</artifactId>
-			<!-- <exclusions>
+			<exclusions>
 				<exclusion>
 					<groupId>xpp3</groupId>
 					<artifactId>xpp3</artifactId>
 				</exclusion>
-			</exclusions>  -->
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -182,7 +182,13 @@
         <dependency>
           <groupId>org.springframework.security.extensions</groupId>
           <artifactId>spring-security-saml2-core</artifactId>
-          <version>1.0.10.RELEASE</version>         
+          <version>1.0.10.RELEASE</version>
+			<exclusions>
+				<exclusion>
+					<groupId>xml-apis</groupId>
+					<artifactId>xml-apis</artifactId>
+				</exclusion>
+			</exclusions>
         </dependency>
         
        

--- a/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
@@ -66,11 +66,10 @@ public class Config {
 	@Value("${mag.xds.iti-18.url:}")
     private String iti18HostUrl;// = "ehealthsuisse.ihe-europe.net:8280/xdstools7/sim/default__ahdis/reg/sq"; // http
     /**
-     * Use if IHE CMPD PHARM instead of XDS (PHARM-1 instead of ITI-18)
+     * URL of ITI-18 endpoint (
      */
-    @Value("${mag.xds.cmpd-pharm:false}")
-    private boolean useCmpdPharm;
-
+    @Value("${mag.xds.pharm-5.url:}")
+    private String pharm5HostUrl;// = "ehealthsuisse.ihe-europe.net:8280/xdstools7/sim/default__ahdis/reg/sq"; // http
     /**
      * URL of ITI-43 endpoint
      */

--- a/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
@@ -57,34 +57,39 @@ public class Config {
    /**
     * Use HTTPS for XDS ?
     */
-	@Value("${mag.xds.https}")
-    private boolean https;// = false;
+	@Value("${mag.xds.https:true}")
+    private boolean https;
     
     /**
      * URL of ITI-18 endpoint (
      */
-	@Value("${mag.xds.iti-18.url}")
+	@Value("${mag.xds.iti-18.url:}")
     private String iti18HostUrl;// = "ehealthsuisse.ihe-europe.net:8280/xdstools7/sim/default__ahdis/reg/sq"; // http
-    
+    /**
+     * Use if IHE CMPD PHARM instead of XDS (PHARM-1 instead of ITI-18)
+     */
+    @Value("${mag.xds.cmpd-pharm:false}")
+    private boolean useCmpdPharm;
+
     /**
      * URL of ITI-43 endpoint
      */
-	@Value("${mag.xds.iti-43.url}")
+	@Value("${mag.xds.iti-43.url:}")
     private String iti43HostUrl;// = "ehealthsuisse.ihe-europe.net:8280/xdstools7/sim/default__ahdis/rep/ret"; // http
     
     /**
      * URL of ITI-41 endpoint
      */
-	@Value("${mag.xds.iti-41.url}")
+	@Value("${mag.xds.iti-41.url:}")
     private String iti41HostUrl;// = "ehealthsuisse.ihe-europe.net:8280/xdstools7/sim/default__ahdis/rep/prb"; // http
     
     /**
      * Own full URL where clients can retrieve documents from 
      */
-	@Value("${mag.xds.retrieve.url}")
+	@Value("${mag.xds.retrieve.url:}")
     private String uriMagXdsRetrieve;// = "https://localhost:9091/camel/xdsretrieve";
     
-	@Value("${mag.xds.retrieve.repositoryUniqueId}")
+	@Value("${mag.xds.retrieve.repositoryUniqueId:}")
 	private String repositoryUniqueId;
 	
     //private String hostUrl45Http = "gazelle.interopsante.org/PAMSimulator-ejb/PIXManager_Service/PIXManager_PortType"; // http
@@ -98,49 +103,49 @@ public class Config {
     /**
      * Use HTTPS for PIX V3?
      */
-	@Value("${mag.pix.https}")
+	@Value("${mag.pix.https:true}")
     private boolean pixHttps;// = true;
     
     /**
      * URL of ITI-45 endpoint
      */
-	@Value("${mag.pix.iti-45.url}")
+	@Value("${mag.pix.iti-45.url:}")
     private String iti45HostUrl;// = "ehealthsuisse.ihe-europe.net:10443/PAMSimulator-ejb/PIXManager_Service/PIXManager_PortType";
     
     /**
      * URL of ITI-44 endpoint
      */
-	@Value("${mag.pix.iti-44.url}")
+	@Value("${mag.pix.iti-44.url:}")
     private String iti44HostUrl;// = iti45HostUrl;
 	
 	/**
 	 * URL of ITI-47 endpoint
 	 */
-	@Value("${mag.pix.iti-47.url}")
+	@Value("${mag.pix.iti-47.url:}")
     private String iti47HostUrl;
     
     /**
      * sender OID used when sending requests
      */
-	@Value("${mag.pix.oids.sender}")
+	@Value("${mag.pix.oids.sender:}")
     private String pixMySenderOid;// = "1.3.6.1.4.1.12559.11.1.2.2.5.7";
     
     /**
      * receiver OID (of target system) used when sending requests
      */
-	@Value("${mag.pix.oids.receiver}")
+	@Value("${mag.pix.oids.receiver:}")
     private String pixReceiverOid;// = "1.3.6.1.4.1.12559.11.1.2.2.5.11";
     
     /**
      * OID for queries
      */
-	@Value("${mag.pix.oids.query}")
+	@Value("${mag.pix.oids.query:}")
     private String pixQueryOid;// = pixMySenderOid;
     
    /**
     * baseurl of gateway
     */
-	@Value("${mag.baseurl}")
+	@Value("${mag.baseurl:}")
 	private String baseurl;
 	 
 	/**
@@ -150,16 +155,18 @@ public class Config {
    
     
    
-    @Value("${mag.client-ssl.key-store}")
+    @Value("${mag.client-ssl.key-store:}")
     private String keystore;
     
-    @Value("${mag.client-ssl.key-store-password}")
+    @Value("${mag.client-ssl.key-store-password:}")
     private String keystorePassword;
     
-    @Value("${mag.client-ssl.cert-alias}")
+    @Value("${mag.client-ssl.cert-alias:}")
     private String certAlias;
     
-   
+    @Value("${mag.audit.audit-tls-enabled:false}")
+    private boolean auditTlsEnabled;
+
     /**
      * Connection security : Use client certificate
      */    
@@ -193,7 +200,9 @@ public class Config {
     @ConfigurationProperties(prefix = "mag.audit")
     public DefaultAuditContext getAuditContext() {
     	DefaultAuditContext context = new DefaultAuditContext();
-    	context.setTlsParameters(new TlsParameterTest(getPixSSLContext()));
+    	if (this.auditTlsEnabled) {
+    	    context.setTlsParameters(new TlsParameterTest(getPixSSLContext()));
+    	}
     	//CustomTlsParameters p = new CustomTlsParameters();
     	
     	//p.setKeyStoreFile("270.jks");

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/PHARM.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/PHARM.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package ch.bfh.ti.i4mi.mag.mhd;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.openehealth.ipf.commons.ihe.core.IntegrationProfile;
+import org.openehealth.ipf.commons.ihe.core.InteractionId;
+import org.openehealth.ipf.commons.ihe.fhir.FhirInteractionId;
+import org.openehealth.ipf.commons.ihe.fhir.FhirTransactionConfiguration;
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditDataset;
+
+import ch.bfh.ti.i4mi.mag.mhd.pharm5.Pharm5TransactionConfiguration;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author Oliver Egger
+ */
+public class PHARM implements IntegrationProfile {
+
+    @AllArgsConstructor
+    public enum Interactions implements FhirInteractionId<FhirQueryAuditDataset> {
+
+        PHARM5(PHARM5_CONFIG);
+
+        @Getter
+        FhirTransactionConfiguration<FhirQueryAuditDataset> fhirTransactionConfiguration;
+    }
+
+    @Override
+    public List<InteractionId> getInteractionIds() {
+        return Arrays.asList(Interactions.values());
+    }
+
+    private static final Pharm5TransactionConfiguration PHARM5_CONFIG = new Pharm5TransactionConfiguration();
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti65/Iti65RouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti65/Iti65RouteBuilder.java
@@ -64,7 +64,7 @@ class Iti65RouteBuilder extends RouteBuilder {
     public void configure() throws Exception {
         log.debug("Iti65RouteBuilder configure");
         
-        final String xds41Endpoint = String.format("xds-iti41://%s/xds/iti41" +
+        final String xds41Endpoint = String.format("xds-iti41://%s" +
                 "?secure=%s", this.config.getIti41HostUrl(), this.config.isHttps() ? "true" : "false")
               +
                       "&audit=true" +

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti66/Iti66RouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti66/Iti66RouteBuilder.java
@@ -47,7 +47,7 @@ class Iti66RouteBuilder extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         log.debug("Iti66RouteBuilder configure");
-        final String xds18Endpoint = String.format("xds-iti18://%s/xds/iti18" +
+        final String xds18Endpoint = String.format("xds-iti18://%s" +
           "?secure=%s", this.config.getIti18HostUrl(), this.config.isHttps() ? "true" : "false")
         +
                 "&audit=true" +

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti67/Iti67RequestConverter.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti67/Iti67RequestConverter.java
@@ -25,8 +25,8 @@ import org.openehealth.ipf.commons.ihe.fhir.iti67.Iti67SearchParameters;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.DocumentEntryType;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Name;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Person;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.ReferenceId;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.XcnName;
@@ -179,10 +179,10 @@ public class Iti67RequestConverter extends BaseRequestConverter {
 	            query.setTypedAuthorPersons(authorPersons);
 	            
             }
-
             final QueryRegistry queryRegistry = new QueryRegistry(query);
             queryRegistry.setReturnType((getLeafClass) ? QueryReturnType.LEAF_CLASS : QueryReturnType.OBJECT_REF);
             
             return queryRegistry;
     }
+
 }

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti67/Iti67RouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti67/Iti67RouteBuilder.java
@@ -47,7 +47,7 @@ class Iti67RouteBuilder extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         log.debug("Iti67RouteBuilder configure");
-        final String endpoint = String.format("xds-iti18://%s/xds/iti18" +
+        final String endpoint = String.format("xds-iti18://%s" +
                 "?secure=%s", this.config.getIti18HostUrl(), this.config.isHttps() ? "true" : "false")
                 +
                 "&audit=true" +

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti67/Pharm1RequestConverter.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti67/Pharm1RequestConverter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.bfh.ti.i4mi.mag.mhd.iti67;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.camel.Body;
+import org.openehealth.ipf.commons.ihe.fhir.iti67.Iti67SearchParameters;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.DocumentEntryType;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.QueryRegistry;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationListQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryReturnType;
+
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.TokenOrListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ch.bfh.ti.i4mi.mag.BaseRequestConverter;
+
+/**
+ * ITI-67 to PHARM-1 request converter
+ * 
+ * @author Oliver Egger
+ *
+ */
+public class Pharm1RequestConverter extends BaseRequestConverter {
+
+    /**
+     * convert ITI-67 request to CMPD Pharm-1
+     * 
+     * @param searchParameter
+     * @return
+     */
+    public QueryRegistry searchParameterIti67ToFindMedicationListQuery(@Body Iti67SearchParameters searchParameter) {
+
+        boolean getLeafClass = true;
+
+        FindMedicationListQuery query = new FindMedicationListQuery();
+
+        // status --> $XDSDocumentEntryStatus
+        TokenOrListParam status = searchParameter.getStatus();
+        if (status != null) {
+            List<AvailabilityStatus> availabilites = new ArrayList<AvailabilityStatus>();
+            for (TokenParam statusToken : status.getValuesAsQueryTokens()) {
+                String tokenValue = statusToken.getValue();
+                if (tokenValue.equals("current"))
+                    availabilites.add(AvailabilityStatus.APPROVED);
+                else if (tokenValue.equals("superseded"))
+                    availabilites.add(AvailabilityStatus.DEPRECATED);
+            }
+            query.setStatus(availabilites);
+        }
+
+        // patient or patient.identifier --> $XDSDocumentEntryPatientId
+        TokenParam tokenIdentifier = searchParameter.getPatientIdentifier();
+        if (tokenIdentifier != null) {
+            String system = getScheme(tokenIdentifier.getSystem());
+            if (system == null)
+                throw new InvalidRequestException("Missing OID for patient");
+            query.setPatientId(new Identifiable(tokenIdentifier.getValue(), new AssigningAuthority(system)));
+        }
+        ReferenceParam patientRef = searchParameter.getPatientReference();
+        if (patientRef != null) {
+            Identifiable id = transformReference(patientRef.getValue());
+            query.setPatientId(id);
+        }
+
+        // format --> $XDSDocumentEntryFormatCode
+        TokenOrListParam formats = searchParameter.getFormat();
+        query.setFormatCodes(codesFromTokens(formats));
+
+        // add on-demand documents also to the query, maybe make it configurable
+        if (true) {
+            List<DocumentEntryType> documentEntryTypes = new ArrayList<DocumentEntryType>();
+            documentEntryTypes.add(DocumentEntryType.ON_DEMAND);
+            documentEntryTypes.add(DocumentEntryType.STABLE);
+            query.setDocumentEntryTypes(documentEntryTypes);
+        }
+
+        final QueryRegistry queryRegistry = new QueryRegistry(query);
+        queryRegistry.setReturnType((getLeafClass) ? QueryReturnType.LEAF_CLASS : QueryReturnType.OBJECT_REF);
+
+        return queryRegistry;
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti68/Iti68ResponseConverter.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti68/Iti68ResponseConverter.java
@@ -42,7 +42,7 @@ import ch.bfh.ti.i4mi.mag.mhd.BaseResponseConverter;
  */
 public class Iti68ResponseConverter extends BaseResponseConverter {
 
-	public Object retrievedDocumentSetToHttResponse(@Body RetrievedDocumentSet retrievedDocumentSet, @Headers Map<String, Object> headers) throws IOException {
+	public static Object retrievedDocumentSetToHttResponse(@Body RetrievedDocumentSet retrievedDocumentSet, @Headers Map<String, Object> headers) throws IOException {
                 		
             if (Status.SUCCESS.equals(retrievedDocumentSet.getStatus())) {
                 List<RetrievedDocument> documentResponses = retrievedDocumentSet.getDocuments();

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti68/Iti68RouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti68/Iti68RouteBuilder.java
@@ -65,8 +65,10 @@ class Iti68RouteBuilder extends RouteBuilder {
                 // translate, forward, translate back
                 .bean(Iti68RequestConverter.class)                
                 .to(xds43Endpoint)
-                .bean(Iti68ResponseConverter.class);
-                //.process(Utils.retrievedDocumentSetToHttResponse());
+                .bean(Iti68ResponseConverter.class,"retrievedDocumentSetToHttResponse"); 
+                // if removing retrievedDocumentSetToHttResponse its given an AmbiguousMethodCallException with two same methods??
+                // public java.lang.Object ch.bfh.ti.i4mi.mag.mhd.iti68.Iti68ResponseConverter.retrievedDocumentSetToHttResponse(org.openehealth.ipf.commons.ihe.xds.core.responses.RetrievedDocumentSet,java.util.Map) throws java.io.IOException,
+                // public java.lang.Object ch.bfh.ti.i4mi.mag.mhd.iti68.Iti68ResponseConverter.retrievedDocumentSetToHttResponse(org.openehealth.ipf.commons.ihe.xds.core.responses.RetrievedDocumentSet,java.util.Map) throws java.io.IOException] 
     }
 
 }

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti68/Iti68RouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti68/Iti68RouteBuilder.java
@@ -47,7 +47,7 @@ class Iti68RouteBuilder extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         log.debug("Iti68RouteBuilder configure");
-        final String xds43Endpoint = String.format("xds-iti43://%s/xds/iti43" +
+        final String xds43Endpoint = String.format("xds-iti43://%s" +
                 "?secure=%s", this.config.getIti43HostUrl(), this.config.isHttps() ? "true" : "false")
                 +
                 "&audit=true" +

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5AuditStrategy.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5AuditStrategy.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.bfh.ti.i4mi.mag.mhd.pharm5;
+
+import org.openehealth.ipf.commons.audit.AuditContext;
+import org.openehealth.ipf.commons.audit.model.AuditMessage;
+import org.openehealth.ipf.commons.ihe.core.atna.event.QueryInformationBuilder;
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditDataset;
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditStrategy;
+import org.openehealth.ipf.commons.ihe.fhir.audit.codes.FhirEventTypeCode;
+import org.openehealth.ipf.commons.ihe.fhir.audit.codes.FhirParticipantObjectIdTypeCode;
+import org.openehealth.ipf.commons.ihe.fhir.support.OperationOutcomeOperations;
+
+/**
+ * Strategy for auditing Pharm5AuditStrategy
+ * TODO: not specified yet by spec
+ *
+ * @author Oliver Eggrer
+ */
+public class Pharm5AuditStrategy extends FhirQueryAuditStrategy {
+
+    public Pharm5AuditStrategy(boolean serverSide) {
+        super(serverSide, OperationOutcomeOperations.INSTANCE);
+    }
+
+    @Override
+    public AuditMessage[] makeAuditMessage(AuditContext auditContext, FhirQueryAuditDataset auditDataset) {
+        return new QueryInformationBuilder<>(auditContext, auditDataset, FhirEventTypeCode.MobilePatientIdentifierCrossReferenceQuery)
+                .addPatients(auditDataset.getPatientIds())
+                .setQueryParameters(
+                        "find-medication-list",
+                        FhirParticipantObjectIdTypeCode.MobileDocumentReferenceQuery,
+                        auditDataset.getQueryString())
+
+                .getMessages();
+    }
+
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5ClientRequestFactory.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5ClientRequestFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.bfh.ti.i4mi.mag.mhd.pharm5;
+
+import java.util.Map;
+
+import org.hl7.fhir.r4.model.DocumentReference;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.StringType;
+import org.openehealth.ipf.commons.ihe.fhir.ClientRequestFactory;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.IClientExecutable;
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
+
+/**
+ * Request Factory for PHARM5 requests
+ *
+ * @author Oliver Egger
+ */
+public class Pharm5ClientRequestFactory implements ClientRequestFactory<IOperationUntypedWithInput<Parameters>> {
+
+    @Override
+    public IClientExecutable<IOperationUntypedWithInput<Parameters>, ?> getClientExecutable(IGenericClient client, Object requestData, Map<String, Object> parameters) {
+
+        if (requestData instanceof Parameters) {
+            return getClientExecutable(client, (Parameters) requestData);
+        } else {
+            var p = new Parameters();
+            parameters.entrySet().stream()
+                    .filter(entry -> Pharm5Constants.PHARM5_PARAMETERS.contains(entry.getKey()))
+                    .forEach(entry -> p.addParameter()
+                            .setName(entry.getKey())
+                            .setValue(new StringType(entry.getValue().toString())));
+            return getClientExecutable(client, p);
+        }
+
+    }
+
+    private IClientExecutable<IOperationUntypedWithInput<Parameters>, ?> getClientExecutable(IGenericClient client, Parameters requestData) {
+        return client.operation()
+                .onType(DocumentReference.class)
+                .named(Pharm5Constants.PHARM5_OPERATION_NAME)
+                .withParameters(requestData)
+                .useHttpGet();
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5Component.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5Component.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.bfh.ti.i4mi.mag.mhd.pharm5;
+
+import static ch.bfh.ti.i4mi.mag.mhd.PHARM.Interactions.PHARM5;
+
+import org.apache.camel.CamelContext;
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditDataset;
+import org.openehealth.ipf.platform.camel.ihe.fhir.core.FhirComponent;
+import org.openehealth.ipf.platform.camel.ihe.fhir.core.FhirEndpointConfiguration;
+
+/**
+ * Component for PHARM5 
+ *
+ */
+public class Pharm5Component extends FhirComponent<FhirQueryAuditDataset> {
+
+
+    public Pharm5Component() {
+        super(PHARM5);
+    }
+
+    public Pharm5Component(CamelContext context) {
+        super(context, PHARM5);
+    }
+
+    @Override
+    protected Pharm5Endpoint doCreateEndpoint(String uri, FhirEndpointConfiguration<FhirQueryAuditDataset> config) {
+        return new Pharm5Endpoint(uri, this, config);
+    }
+ 
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5Constants.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5Constants.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.bfh.ti.i4mi.mag.mhd.pharm5;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Oliver Egger
+ */
+public interface Pharm5Constants {
+
+    final String PHARM5_OPERATION_NAME = "$find-medication-list";
+    final String PHARM5_STATUS = "status";
+    final String PHARM5_PATIENT_IDENTIFIER = "patient.identifier";
+
+    // needs to be extended
+    Set<String> PHARM5_PARAMETERS = new HashSet<>(Arrays.asList(
+            PHARM5_STATUS,
+            PHARM5_PATIENT_IDENTIFIER));
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5Endpoint.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5Endpoint.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.bfh.ti.i4mi.mag.mhd.pharm5;
+
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditDataset;
+import org.openehealth.ipf.platform.camel.ihe.fhir.core.FhirEndpoint;
+import org.openehealth.ipf.platform.camel.ihe.fhir.core.FhirEndpointConfiguration;
+
+/**
+ * @author Oliver Egger
+ */
+public class Pharm5Endpoint extends FhirEndpoint<FhirQueryAuditDataset, Pharm5Component> {
+
+    public Pharm5Endpoint(String uri, Pharm5Component fhirComponent, FhirEndpointConfiguration<FhirQueryAuditDataset> config) {
+        super(uri, fhirComponent, config);
+    }
+
+    @Override
+    protected String createEndpointUri() {
+        return "mhd-pharm5:" + "not-implemented yet";
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5ResourceProvider.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5ResourceProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.bfh.ti.i4mi.mag.mhd.pharm5;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DocumentReference;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.StringType;
+import org.openehealth.ipf.commons.ihe.fhir.AbstractPlainProvider;
+
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+
+/**
+ * This operation is the correspondence to the IHE CMPD PHARM-1 transaction but as an MHD extensios instead of XDS
+ *
+ * @author Oliver Egger
+ */
+public class Pharm5ResourceProvider extends AbstractPlainProvider {
+
+    /**
+     * Handles the PHARM5 Transactions
+     *
+     * @return {@link Parameters} containing found identifiers
+     */
+    @SuppressWarnings("unused")
+    @Operation(name = Pharm5Constants.PHARM5_OPERATION_NAME, type = DocumentReference.class, idempotent = true, returnParameters = {@OperationParam(name = "return", type = Bundle.class, max = 100)})
+    public IBundleProvider findMedicationList(
+            @IdParam(optional = true) IdType resourceId,
+            @OperationParam(name = Pharm5Constants.PHARM5_PATIENT_IDENTIFIER) TokenParam patientIdentifier,
+            @OperationParam(name = Pharm5Constants.PHARM5_STATUS) StringParam status,
+            RequestDetails requestDetails,
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse) {
+
+        var sourceIdentifier = new Identifier();
+
+        if (resourceId == null) {
+            sourceIdentifier.setSystem(patientIdentifier.getSystem())
+                    .setValue(patientIdentifier.getValue());
+        } else {
+            sourceIdentifier.setValue(resourceId.getIdPart());
+        }
+        var statusType = status == null ? null : new StringType(status.getValue());
+  
+        var inParams = new Parameters();
+        inParams.addParameter().setName(Pharm5Constants.PHARM5_PATIENT_IDENTIFIER).setValue(sourceIdentifier);
+        inParams.addParameter().setName(Pharm5Constants.PHARM5_STATUS).setValue(statusType);
+        
+        return requestBundleProvider(inParams, null, ResourceType.DocumentReference.name(),
+                httpServletRequest, httpServletResponse, requestDetails);
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5RouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5RouteBuilder.java
@@ -45,7 +45,7 @@ class Pharm5RouteBuilder extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         log.debug("Pharm5RouteBuilder configure");
-        final String endpoint = String.format("cmpd-pharm1://%s/xds/pharm1" +
+        final String endpoint = String.format("cmpd-pharm1://%s" +
                 "?secure=%s", this.config.getPharm5HostUrl(), this.config.isHttps() ? "true" : "false")
                 +
                 "&audit=true" +

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5TransactionConfiguration.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5TransactionConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.bfh.ti.i4mi.mag.mhd.pharm5;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import org.openehealth.ipf.commons.ihe.fhir.FhirTransactionConfiguration;
+import org.openehealth.ipf.commons.ihe.fhir.FhirTransactionValidator;
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditDataset;
+
+/**
+ * Standard Configuration for Iti83Component. Lazy-loading of results is by default not supported.
+ *
+ * @author Christian Ohr
+ * @since 3.6
+ */
+public class Pharm5TransactionConfiguration extends FhirTransactionConfiguration<FhirQueryAuditDataset> {
+
+    public Pharm5TransactionConfiguration() {
+        super(
+                "mhd-pharm5",
+                "FindMedicationList",
+                true,
+                new Pharm5AuditStrategy(false),
+                new Pharm5AuditStrategy(true),
+                FhirVersionEnum.R4,
+                new Pharm5ResourceProvider(),
+                new Pharm5ClientRequestFactory(),
+                FhirTransactionValidator.NO_VALIDATION);
+        setSupportsLazyLoading(false);
+    }
+
+}

--- a/src/main/resources/META-INF/services/org/apache/camel/component/mhd-pharm5
+++ b/src/main/resources/META-INF/services/org/apache/camel/component/mhd-pharm5
@@ -1,0 +1,12 @@
+#    Copyright 2015 the original author or authors. Licensed under the Apache
+#    License, Version 2.0 (the "License"); you may not use this file except
+#    in compliance with the License. You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+#    law or agreed to in writing, software distributed under the License is
+#    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#    KIND, either express or implied. See the License for the specific
+#    language governing permissions and limitations under the License.
+
+# Camel registration for the pharm5.Pharm5Componen
+ 
+class=ch.bfh.ti.i4mi.mag.mhd.pharm5.Pharm5Component

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 # General configuration of the IPF application.
 
 mag:
-  baseurl: https://mobileaccessgateway.pagekite.me
+  baseurl: http://test.ahdis.ch
   client-ssl:
     enabled: true
     key-store: 270.jks
@@ -19,7 +19,7 @@ mag:
     iti-41:
       url: ehealthsuisse.ihe-europe.net:10443/xdstools7/sim/default__ahdis/rep/prb
     retrieve:
-      url: https://mobileaccessgateway.pagekite.me/camel/xdsretrieve
+      url: http://test.ahdis.ch/camel/xdsretrieve
       repositoryUniqueId: 1.1.4567332.1.2
       #repositoryUniqueId: 1.3.6.1.4.1.21367.2017.2.3.54
   pix:

--- a/src/test/resources/mhdch.json
+++ b/src/test/resources/mhdch.json
@@ -39,7 +39,7 @@
           }
         ],
         "masterIdentifier": {
-          "value": "urn:oid:1.3.6.1.4.1.12559.11.13.2.6.3000.2"
+          "value": "urn:oid:1.3.6.1.4.1.12559.11.13.2.6.3000.3"
         },
         "identifier": [
           {
@@ -58,7 +58,7 @@
           ]
         },
         "subject": {
-          "reference": "http://test.ahdis.ch/fhir/Patient/1.3.6.1.4.1.21367.2017.2.5.83-MAG-001"
+          "reference": "http://test.ahdis.ch/fhir/Patient/1.3.6.1.4.1.21367.2017.2.5.83-MAG-002"
         },
         "created": "2020-06-29T12:01:30+00:00",
         "source": "urn:oid:1.3.6.1.4.1.12559.11.13.2.5",
@@ -112,7 +112,7 @@
           }
         ],
         "masterIdentifier": {
-          "value": "urn:oid:1.3.6.1.4.1.12559.11.13.2.1.3000.2"
+          "value": "urn:oid:1.3.6.1.4.1.12559.11.13.2.1.3000.3"
         },
         "identifier": [
           {
@@ -143,10 +143,10 @@
           }
         ],
         "subject": {
-          "reference": "http://test.ahdis.ch/fhir/Patient/1.3.6.1.4.1.21367.2017.2.5.83-MAG-001"
+          "reference": "http://test.ahdis.ch/fhir/Patient/1.3.6.1.4.1.21367.2017.2.5.83-MAG-002"
         },
-        "date": "2020-06-29T11:58:00+00:00",
-        "description": "2-7-MedicationCard",
+        "date": "2020-08-13T11:58:00+00:00",
+        "description": "2-7-MedicationCard (2tes Mal)",
         "securityLabel": [
           {
             "coding": [
@@ -164,7 +164,7 @@
               "contentType": "text/xml",
               "language": "de-CH",
               "url": "urn:uuid:d8d1fe44-07e9-4a84-985f-fde97d77d54b",
-              "creation": "2020-06-29T11:58:00+00:00"
+              "creation": "2020-08-13T11:58:00+00:00"
             },
             "format": {
               "system": "urn:oid:1.3.6.1.4.1.19376.1.2.3",


### PR DESCRIPTION
for the pharm1 there is a iti-18 based query, however it differs
- other soap action name
- on demand documents need to be requested query excplicitly

a new propery      

mag.xds.cmpd-pharm

has been added to indicate if mhd should use the pharm-1 transaction instead of iti-18