### PR TITLE
add formatType parameter for PHARM-1

### DIFF
--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5Constants.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5Constants.java
@@ -28,9 +28,11 @@ public interface Pharm5Constants {
     final String PHARM5_OPERATION_NAME = "$find-medication-list";
     final String PHARM5_STATUS = "status";
     final String PHARM5_PATIENT_IDENTIFIER = "patient.identifier";
+    final String PHARM5_FORMAT = "format";
 
     // needs to be extended
     Set<String> PHARM5_PARAMETERS = new HashSet<>(Arrays.asList(
             PHARM5_STATUS,
-            PHARM5_PATIENT_IDENTIFIER));
+            PHARM5_PATIENT_IDENTIFIER,
+            PHARM5_FORMAT));
 }

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5RequestConverter.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5RequestConverter.java
@@ -20,21 +20,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.camel.Body;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Parameters;
-import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Type;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.DocumentEntryType;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.QueryRegistry;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationListQuery;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryReturnType;
 
-import ca.uhn.fhir.rest.param.ReferenceParam;
-import ca.uhn.fhir.rest.param.TokenOrListParam;
-import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ch.bfh.ti.i4mi.mag.BaseRequestConverter;
 
@@ -80,6 +78,23 @@ public class Pharm5RequestConverter extends BaseRequestConverter {
             if (system == null || !system.startsWith("urn:oid:"))
                 throw new InvalidRequestException("Missing OID for patient");
             query.setPatientId(new Identifiable(patIdentifier.getValue(), new AssigningAuthority(system.substring(8))));
+        }
+
+        List<Type> formatTypes = searchParameter.getParameters(Pharm5Constants.PHARM5_FORMAT);
+        if (formatTypes!=null && formatTypes.size()>0) {
+            List<Code> formatCodes = new ArrayList<Code>();
+            for (Type format : formatTypes) {
+                Coding formatCoding = (Coding) format;
+                Code formatCode = new Code();
+                formatCode.setCode(formatCoding.getCode());
+                String system = formatCoding.getSystem();
+                if (system.startsWith("urn:oid:")) {
+                    system = system.substring(8);
+                }
+                formatCode.setSchemeName(system);
+                formatCodes.add(formatCode);
+            }
+            query.setFormatCodes(formatCodes);
         }
 
         List<DocumentEntryType> documentEntryTypes = new ArrayList<DocumentEntryType>();

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5ResourceProvider.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5ResourceProvider.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Identifier;
@@ -54,10 +55,12 @@ public class Pharm5ResourceProvider extends AbstractPlainProvider {
             @IdParam(optional = true) IdType resourceId,
             @OperationParam(name = Pharm5Constants.PHARM5_PATIENT_IDENTIFIER) TokenParam patientIdentifier,
             @OperationParam(name = Pharm5Constants.PHARM5_STATUS) StringParam status,
+            @OperationParam(name = Pharm5Constants.PHARM5_FORMAT) TokenParam format,
             RequestDetails requestDetails,
             HttpServletRequest httpServletRequest,
             HttpServletResponse httpServletResponse) {
 
+    	// FIXME format should be TokenAndListParam
         var sourceIdentifier = new Identifier();
 
         if (resourceId == null) {
@@ -67,10 +70,20 @@ public class Pharm5ResourceProvider extends AbstractPlainProvider {
             sourceIdentifier.setValue(resourceId.getIdPart());
         }
         var statusType = status == null ? null : new StringType(status.getValue());
-  
+
+        
+        Coding formatCoding = null;
+        if (format!=null) {
+            formatCoding = new Coding();
+            formatCoding.setSystem(format.getSystem()).setCode(format.getValue());
+        }
+
         var inParams = new Parameters();
         inParams.addParameter().setName(Pharm5Constants.PHARM5_PATIENT_IDENTIFIER).setValue(sourceIdentifier);
         inParams.addParameter().setName(Pharm5Constants.PHARM5_STATUS).setValue(statusType);
+        if (formatCoding!=null) {
+          inParams.addParameter().setName(Pharm5Constants.PHARM5_FORMAT).setValue(formatCoding);
+        }
         
         return requestBundleProvider(inParams, null, ResourceType.DocumentReference.name(),
                 httpServletRequest, httpServletResponse, requestDetails);


### PR DESCRIPTION
Pharm-1 has an 0..* format Parameter that the document according to the specified format. This PR adds the format parameter to the $find-medication-list operation which will be translated to the formatType parameter, e.g:

https://test.ahdis.ch/mag-pmp/fhir/DocumentReference/$find-medication-list?status=current&patient.identifier=urn:oid:2.999.756.42.2|CARAMED001&format=urn:oid:2.16.756.5.30.1.127.3.10.10|urn:ch:cda-ch-emed:medication-card:2018