### PR TITLE
NP for fhir/metadata with latest version #56

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
 
 		<java.version>11</java.version>
 
-		<ipf-version>4.1.0</ipf-version>
-		<camel-version>3.7.0</camel-version>
+		<ipf-version>4.2-SNAPSHOT</ipf-version>
+		<camel-version>3.11.2</camel-version>
 		<start-class>ch.bfh.ti.i4mi.mag.MobileAccessGateway</start-class>
 	</properties>
 
@@ -209,7 +209,7 @@
         <dependency>
           <groupId>org.apache.camel</groupId>
           <artifactId>camel-jackson</artifactId>
-          <version>3.5.0</version>        
+          <version>${camel-version}</version>
         </dependency>
         
         <dependency>

--- a/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
@@ -274,6 +274,7 @@ public class Config {
     public FilterRegistrationBean<Filter> corsFilterRegistration() {
         var frb = new FilterRegistrationBean<>();
         // Overwirte cors, otherwise we cannot access /camel/ via javascript
+        // need to crosscheck with ch.bfh.ti.i4mi.mag.xuaSamlIDPIntegration
         frb.addUrlPatterns("/fhir/*", "/camel/*");
         frb.setFilter(new CorsFilter(request -> defaultCorsConfiguration()));
         return frb;

--- a/src/main/java/ch/bfh/ti/i4mi/mag/MobileAccessGateway.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/MobileAccessGateway.java
@@ -20,7 +20,10 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @SpringBootApplication
 @Slf4j
-@ComponentScan(basePackages={"org.openehealth.ipf","ch.bfh.ti.i4mi.mag","org.springframework.security.saml"})	
+@ComponentScan(basePackages={"ch.bfh.ti.i4mi.mag","org.openehealth.ipf","org.springframework.security.saml"})	
 // without it does not work directly with mvn and current snapshot, when running the Pixm query an error is returned   "resourceType": "OperationOutcome", "issue": [ { "severity": "error", "code": "processing", "diagnostics": "Unknown resource type 'Patient' - Server knows how to handle: [StructureDefinition, OperationDefinition]" } ]
 // it looks like the META-INF directory is not correct configured that is copied to the output, if it is added in eclipse as on open project to java/main/resources it works without above line 
 @EnableAutoConfiguration

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti65/Iti65RequestConverter.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti65/Iti65RequestConverter.java
@@ -217,8 +217,11 @@ public class Iti65RequestConverter {
 	                	Binary binary = (Binary) binaryContent;	         
 	                	if (binary.hasContentType() && !binary.getContentType().equals(contentType)) throw new InvalidRequestException("ContentType in Binary and in DocumentReference must match");
 	                	doc.setDataHandler(new DataHandler(new ByteArrayDataSource(binary.getData(),contentType)));
-	                	entry.setSize((long) binary.getData().length);
-	                    entry.setHash(SHAsum(binary.getData()));
+	
+	// CARA PMP "text": "The provided size metadata does not match the content in document '%s' [IHE ITI Technical Framework Volume 2b (3.41.4.1.3)]."
+	// FIXME: Assuming if this needs to be set we have to calculated it not in the base64 encoded but directly on the binary encoding 
+	//                	entry.setSize((long) binary.getData().length);
+	//                    entry.setHash(SHAsum(binary.getData()));
 	                	Identifier masterIdentifier = documentReference.getMasterIdentifier();
 	                    binary.setUserData("masterIdentifier", noPrefix(masterIdentifier.getValue()));	                	
                     }
@@ -979,6 +982,12 @@ public class Iti65RequestConverter {
 		if (author == null || author.getReference() == null) {
 		    if (authorRole!=null) {
 	            Author result = new Author();
+	            Person person = new Person();
+	            // CARA PMP 
+	            // At least an authorPerson, authorTelecommunication, or authorInstitution sub-attribute must be present 
+	            // Either authorPerson, authorInstitution or authorTelecom shall be specified in the SubmissionSet [IHE ITI Technical Framework Volume 3 (4.2.3.1.4)].
+	            person.setName(transform(new HumanName().setFamily("---")));
+	            result.setAuthorPerson(person);
 	            result.getAuthorRole().add(authorRole);
 	            return result;
 		    }


### PR DESCRIPTION
first try for a fix that metadata works back again, however the capability statement is not not filled in correctly anymore #56
ugpraded to snapshot which uses versin 5.5.1 form hapi-fhir