### PR TITLE
increase header size for xdsretrieve

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,7 +68,7 @@ mag:
 # https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#server-properties
 
 server:
-  max-http-header-size: 10000
+  max-http-header-size: 15000
   ssl:
     key-store: classpath:example-server-certificate.p12    
     key-store-password: a1b2c3    


### PR DESCRIPTION
with a hin assertion we experienced for the xds retrieve header size of 10k, this PR increases the max size to 15000