### PR TITLE
add support for pharm1 serviceStart, serviceEnd

### DIFF
--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/SchemeMapper.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/SchemeMapper.java
@@ -63,6 +63,9 @@ public class SchemeMapper {
 	 * @return
 	 */
 	public String getScheme(String system) {
+		if (system==null) {
+			return null;
+		}
 		String scheme = systemToScheme.get(system);
 		if (scheme != null) return scheme;
 		if (system.startsWith("urn:oid:")) {

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5Constants.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5Constants.java
@@ -29,10 +29,18 @@ public interface Pharm5Constants {
     final String PHARM5_STATUS = "status";
     final String PHARM5_PATIENT_IDENTIFIER = "patient.identifier";
     final String PHARM5_FORMAT = "format";
+    final String PHARM5_SERVICE_START_FROM = "serviceStartFrom";
+    final String PHARM5_SERVICE_START_TO = "serviceStartTo";
+    final String PHARM5_SERVICE_END_FROM = "serviceEndFrom";
+    final String PHARM5_SERVICE_END_TO = "serviceEndTo";
 
     // needs to be extended
     Set<String> PHARM5_PARAMETERS = new HashSet<>(Arrays.asList(
             PHARM5_STATUS,
             PHARM5_PATIENT_IDENTIFIER,
-            PHARM5_FORMAT));
+            PHARM5_FORMAT,
+            PHARM5_SERVICE_START_FROM,
+            PHARM5_SERVICE_START_TO,
+            PHARM5_SERVICE_END_FROM,
+            PHARM5_SERVICE_END_TO));
 }

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5ResourceProvider.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/pharm5/Pharm5ResourceProvider.java
@@ -56,6 +56,10 @@ public class Pharm5ResourceProvider extends AbstractPlainProvider {
             @OperationParam(name = Pharm5Constants.PHARM5_PATIENT_IDENTIFIER) TokenParam patientIdentifier,
             @OperationParam(name = Pharm5Constants.PHARM5_STATUS) StringParam status,
             @OperationParam(name = Pharm5Constants.PHARM5_FORMAT) TokenParam format,
+            @OperationParam(name = Pharm5Constants.PHARM5_SERVICE_START_FROM) StringParam serviceStartFrom,
+            @OperationParam(name = Pharm5Constants.PHARM5_SERVICE_START_TO) StringParam serviceStartTo,
+            @OperationParam(name = Pharm5Constants.PHARM5_SERVICE_END_FROM) StringParam serviceEndFrom,
+            @OperationParam(name = Pharm5Constants.PHARM5_SERVICE_END_TO) StringParam serviceEndTo,
             RequestDetails requestDetails,
             HttpServletRequest httpServletRequest,
             HttpServletResponse httpServletResponse) {
@@ -84,6 +88,18 @@ public class Pharm5ResourceProvider extends AbstractPlainProvider {
         if (formatCoding!=null) {
           inParams.addParameter().setName(Pharm5Constants.PHARM5_FORMAT).setValue(formatCoding);
         }
+        if (serviceStartFrom!=null) {
+          inParams.addParameter().setName(Pharm5Constants.PHARM5_SERVICE_START_FROM).setValue(new StringType(serviceStartFrom.getValue()));
+        }
+        if (serviceStartTo!=null) {
+            inParams.addParameter().setName(Pharm5Constants.PHARM5_SERVICE_START_TO).setValue(new StringType(serviceStartTo.getValue()));
+          }
+        if (serviceEndFrom!=null) {
+            inParams.addParameter().setName(Pharm5Constants.PHARM5_SERVICE_END_FROM).setValue(new StringType(serviceEndFrom.getValue()));
+          }
+        if (serviceEndTo!=null) {
+            inParams.addParameter().setName(Pharm5Constants.PHARM5_SERVICE_END_TO).setValue(new StringType(serviceEndTo.getValue()));
+          }
         
         return requestBundleProvider(inParams, null, ResourceType.DocumentReference.name(),
                 httpServletRequest, httpServletResponse, requestDetails);


### PR DESCRIPTION
Support for FindMedcationList

FindMedicationList
This query differs from the previous ones as it creates an on-demand document entry containing the query. Effective content is created when the document is retrieved, i.e. when ITI-43, ITI-68 or ITI-39 are called. However, for clarity and coherence with the IHE profiles, its behaviour is described here.
FindMedicationList creates a medication list based on the Pharmacy Medication List (PML) Profile. Different lists may be produced depend-ing on the XDSDocumentEntryFormatCode value as described below.
Key selection criteria are handled the following way (refer to IHE Phar-macy CMPD profile for explanation of the other selection criteria):


XDSDocumentEntryServiceStartFrom/To:
This query parameter is used to find all medication treatments that were started (i.e. became active, see 6.4.1.3) during the in-terval specified by the requester.

$XDSDocumentEntryServiceEndFrom/To:
This query parameter is used to find all medication treatments that were finished / completed (i.e. became inactive, see 6.4.1.3) in the interval specified by the requester.


