### PR TITLE
never reuse session cookie after authentication has been granted.

### DIFF
--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/Utils.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/Utils.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.camel.Body;
 import org.apache.camel.Headers;
 import org.apache.camel.Processor;
+import org.apache.camel.http.common.HttpMessage;
 import org.hl7.fhir.r4.model.Patient;
 import org.openehealth.ipf.commons.ihe.fhir.Constants;
 import org.openehealth.ipf.commons.ihe.fhir.FhirSearchParameters;
@@ -80,6 +81,12 @@ public class Utils {
         return exchange -> {
         	exchange.setProperty(KEPT_BODY, exchange.getIn().getBody());        	        
         };
+    }
+    
+    public static Processor endHttpSession() {
+    	return exchange -> {
+    		exchange.getIn(HttpMessage.class).getRequest().getSession().invalidate();
+    	};
     }
     
     /**

--- a/src/main/java/ch/bfh/ti/i4mi/mag/xua/AssertionFromIdpTokenRouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/xua/AssertionFromIdpTokenRouteBuilder.java
@@ -23,6 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import ch.bfh.ti.i4mi.mag.mhd.Utils;
+
 @Component
 public class AssertionFromIdpTokenRouteBuilder extends RouteBuilder {
 	@Value("${mag.iua.ap.url}")
@@ -53,7 +55,8 @@ public class AssertionFromIdpTokenRouteBuilder extends RouteBuilder {
 				assertionEndpointUrl, wsdl);
 			
 		from("servlet://assertion?httpMethodRestrict=POST&matchOnUriPrefix=true").routeId("assertionFromIdpToken")	
-		.doTry()		    
+		.doTry()	
+		    .process(Utils.endHttpSession())
 		    .bean(AuthRequestConverter.class, "buildAssertionRequestFromIdp")
 			.bean(Iti40RequestGenerator.class, "buildAssertion")			
 			.removeHeaders("*", "scope")

--- a/src/main/java/ch/bfh/ti/i4mi/mag/xua/Iti71RouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/xua/Iti71RouteBuilder.java
@@ -24,6 +24,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import ch.bfh.ti.i4mi.mag.mhd.Utils;
+
 /**
  * IUA: ITI-71 Define route for Get-X-User-Assertion
  *
@@ -61,6 +63,7 @@ public class Iti71RouteBuilder extends RouteBuilder {
 		from("servlet://authorize?matchOnUriPrefix=true").routeId("iti71")	
 		.doTry()
 		    .setHeader("oauthrequest").method(converter, "buildAuthenticationRequest")
+		    .process(Utils.endHttpSession())
 		    .bean(AuthRequestConverter.class, "buildAssertionRequest")
 			.bean(Iti40RequestGenerator.class, "buildAssertion")
 			


### PR DESCRIPTION
Avoids use of already expired IDP token.