### PR TITLE
allow Scope on camel/assertion (cors)

### DIFF
--- a/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
@@ -297,7 +297,7 @@ public class Config {
         // A comma separated list of allowed headers when making a non simple CORS request.
         cors.setAllowedHeaders(Arrays.asList("Origin", "Accept", "Content-Type",
                 "Access-Control-Request-Method", "Access-Control-Request-Headers", "Authorization",
-                "Prefer", "If-Match", "If-None-Match", "If-Modified-Since", "If-None-Exist"));
+                "Prefer", "If-Match", "If-None-Match", "If-Modified-Since", "If-None-Exist", "Scope"));
         cors.setExposedHeaders(Arrays.asList("Location", "Content-Location", "ETag", "Last-Modified"));
         cors.setMaxAge(300L);
         return cors;


### PR DESCRIPTION
To get an assertion you need to do a POST on camel/assertion an add an Scope Header,
however this is restricted due to CORS iif the server is different. This PR adds the Scope http Header aas allowed for non-simple requestes.

POST https://test.ahdis.ch/mag-cara/camel/assertion
mit Body = Assertion
und einem IUA kompatiblen "Scope" Header, z.B:

person_id=761337610410555925^^^&2.16.756.5.30.1.127.3.10.3&ISO purpose_of_use=urn:oid:2.16.756.5.30.1.127.3.10.5|AUTO subject_role=urn:oid:2.16.756.5.30.1.127.3.10.6|TCU principal_id=2000040030829 principal=Oliver+Egger