### PR TITLE
Add OAuth URLs to the CapabilityStatement

### DIFF
--- a/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 
 import javax.servlet.Filter;
 
+import ca.uhn.fhir.rest.server.*;
+import ch.bfh.ti.i4mi.mag.fhir.MagCapabilityStatementProvider;
 import org.apache.camel.support.jsse.KeyManagersParameters;
 import org.apache.camel.support.jsse.KeyStoreParameters;
 import org.apache.camel.support.jsse.SSLContextParameters;
@@ -43,10 +45,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.filter.CorsFilter;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.server.HardcodedServerAddressStrategy;
-import ca.uhn.fhir.rest.server.IServerConformanceProvider;
-import ca.uhn.fhir.rest.server.ResourceBinding;
-import ca.uhn.fhir.rest.server.RestfulServerConfiguration;
 import ca.uhn.fhir.rest.server.provider.ServerCapabilityStatementProvider;
 import ch.bfh.ti.i4mi.mag.mhd.SchemeMapper;
 import ch.bfh.ti.i4mi.mag.pmir.PatientReferenceCreator;
@@ -369,20 +367,19 @@ public class Config {
     }
 
     @Bean
-    public IServerConformanceProvider<IBaseConformance> serverConformanceProvider(FhirContext fhirContext,
-            RestfulServerConfiguration theServerConfiguration) {
-        return new ServerCapabilityStatementProvider(fhirContext, theServerConfiguration);
+    public MagCapabilityStatementProvider serverConformanceProvider(
+            final RestfulServer fhirServer,
+            @Value("${mag.baseurl}") final String baseUrl) {
+        return new MagCapabilityStatementProvider(fhirServer, baseUrl);
     }
 
     // use to fix https://github.com/i4mi/MobileAccessGateway/issues/56, however we have the CapabilityStatement not filled out anymore
-    @SuppressWarnings("unchecked")
 	@Bean
     public RestfulServerConfiguration serverConfiguration() {
         RestfulServerConfiguration config = new RestfulServerConfiguration();
-        config.setResourceBindings(new ArrayList<ResourceBinding>());
-        config.setServerBindings(new ArrayList());
+        config.setResourceBindings(new ArrayList<>());
+        config.setServerBindings(new ArrayList<>());
         config.setServerAddressStrategy(new HardcodedServerAddressStrategy(getUriFhirEndpoint()));
         return config;
     }
-
 }

--- a/src/main/java/ch/bfh/ti/i4mi/mag/fhir/MagCapabilityStatementProvider.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/fhir/MagCapabilityStatementProvider.java
@@ -1,0 +1,47 @@
+package ch.bfh.ti.i4mi.mag.fhir;
+
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import ch.bfh.ti.i4mi.mag.xua.Iti71RouteBuilder;
+import ch.bfh.ti.i4mi.mag.xua.TokenEndpointRouteBuilder;
+import org.hl7.fhir.instance.model.api.IBaseConformance;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.StringType;
+import org.openehealth.ipf.commons.ihe.fhir.support.NullsafeServerCapabilityStatementProvider;
+import org.springframework.beans.factory.annotation.Value;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * A customized provider of the server CapabilityStatement that adds the OAuth URIs extension.
+ *
+ * @author Quentin Ligier
+ */
+@Interceptor
+public class MagCapabilityStatementProvider extends NullsafeServerCapabilityStatementProvider {
+
+    private final String baseUrl;
+
+    public MagCapabilityStatementProvider(final RestfulServer fhirServer,
+                                          @Value("${mag.baseurl}") final String baseUrl) {
+        super(fhirServer);
+        fhirServer.setServerConformanceProvider(this);
+        this.baseUrl = baseUrl + "/camel/";
+    }
+
+    @Override
+    public IBaseConformance getServerConformance(HttpServletRequest theRequest, RequestDetails theRequestDetails) {
+        final var conformance = (CapabilityStatement) super.getServerConformance(theRequest, theRequestDetails);
+
+        conformance.getRestFirstRep().getSecurity().addExtension()
+                .setUrl("http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris")
+                .addExtension(new Extension("token",
+                                            new StringType(this.baseUrl + TokenEndpointRouteBuilder.TOKEN_PATH)))
+                .addExtension(new Extension("authorize",
+                                            new StringType(this.baseUrl + Iti71RouteBuilder.AUTHORIZE_PATH)));
+
+        return conformance;
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/xua/Iti71RouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/xua/Iti71RouteBuilder.java
@@ -33,6 +33,8 @@ import ch.bfh.ti.i4mi.mag.mhd.Utils;
 @Component
 public class Iti71RouteBuilder extends RouteBuilder {
 
+	public static final String AUTHORIZE_PATH = "authorize";
+
 	@Value("${mag.iua.ap.url}")
 	private String assertionEndpointUrl;
 	
@@ -60,7 +62,7 @@ public class Iti71RouteBuilder extends RouteBuilder {
                 (clientSsl ? "&sslContextParameters=#sslContext" : ""),
 				assertionEndpointUrl, wsdl);
 			
-		from("servlet://authorize?matchOnUriPrefix=true").routeId("iti71")	
+		from(String.format("servlet://%s?matchOnUriPrefix=true", AUTHORIZE_PATH)).routeId("iti71")
 		.doTry()
 		    .setHeader("oauthrequest").method(converter, "buildAuthenticationRequest")
 		    

--- a/src/main/java/ch/bfh/ti/i4mi/mag/xua/TokenEndpointRouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/xua/TokenEndpointRouteBuilder.java
@@ -22,29 +22,29 @@ import org.springframework.stereotype.Component;
 
 /**
  * IUA ITI-71: Route for token exchange
- * @author alexander kreutz
  *
+ * @author alexander kreutz
  */
 @Component
 public class TokenEndpointRouteBuilder extends RouteBuilder {
 
-	@Override
-	public void configure() throws Exception {
-									
-		from("servlet://token?httpMethodRestrict=POST&matchOnUriPrefix=true").routeId("tokenEndpoint")
-		.doTry()
-	      .bean(TokenEndpoint.class, "handle")
-	    .doCatch(AuthException.class)
-	      .setBody(simple("${exception}"))
-	      .bean(TokenEndpoint.class, "handleError")
-	      .setHeader(Exchange.HTTP_RESPONSE_CODE, simple("${exception.status}"))
-	    .end()
-	    .removeHeaders("*", Exchange.HTTP_RESPONSE_CODE)
-	    .setHeader("Cache-Control", constant("no-store"))
-	    .setHeader("Pragma", constant("no-cache"))
-		.marshal().json();		
-		
-	}
+    public static final String TOKEN_PATH = "token";
 
-	
+    @Override
+    public void configure() throws Exception {
+        from(String.format("servlet://%s?httpMethodRestrict=POST&matchOnUriPrefix=true", TOKEN_PATH))
+                .routeId("tokenEndpoint")
+                .doTry()
+                    .bean(TokenEndpoint.class, "handle")
+                .doCatch(AuthException.class)
+                    .setBody(simple("${exception}"))
+                    .bean(TokenEndpoint.class, "handleError")
+                    .setHeader(Exchange.HTTP_RESPONSE_CODE, simple("${exception.status}"))
+                .end()
+                .removeHeaders("*", Exchange.HTTP_RESPONSE_CODE)
+                .setHeader("Cache-Control", constant("no-store"))
+                .setHeader("Pragma", constant("no-cache"))
+                .marshal()
+                .json();
+    }
 }


### PR DESCRIPTION
Fixes #135

```json
{
  "resourceType": "CapabilityStatement",
  "id": "58c3b803-db31-41ce-be2b-7bff6995e74f",
  "name": "RestServer",
  "status": "active",
  "date": "2024-02-29T10:44:50.071+01:00",
  "publisher": "Not provided",
  "kind": "instance",
  "software": {
    "name": "HAPI FHIR Server",
    "version": "6.8.3"
  },
  "implementation": {
    "description": "HAPI FHIR",
    "url": "http://localhost:9090/mag-pmp2/fhir"
  },
  "fhirVersion": "4.0.1",
  "format": [ "application/fhir+xml", "xml", "application/fhir+json", "json", "html/json", "html/xml" ],
  "rest": [ {
    "mode": "server",
    "security": {
      "extension": [ {
        "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
        "extension": [ {
          "url": "token",
          "valueString": "https://test.ahdis.ch/mag-pmp2/camel/token"
        }, {
          "url": "authorize",
          "valueString": "https://test.ahdis.ch/mag-pmp2/camel/authorize"
        } ]
      } ]
    },
    "resource": [ {
```