### PR TITLE
Fix coding system OID for originalProviderRole

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 - Upgraded to IPF 4.8-m2
 - Removed dependency on IHE-Europe STS simulator
 - Support for email in real case scenario with invalid contact infos [#138](https://github.com/i4mi/MobileAccessGateway/pull/138)
+- Fixed coding system OIDs of document author and uploader role codes
 
 ## 2024/02/08 v062
 

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/BaseQueryResponseConverter.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/BaseQueryResponseConverter.java
@@ -387,8 +387,8 @@ public abstract class BaseQueryResponseConverter extends BaseResponseConverter i
     	if (author == null) return false;
     	if (author.getAuthorRole()==null) return false;
     	for (Identifiable roles : author.getAuthorRole()) {
-    		if ("PAT".equals(roles.getId()) && "2.16.756.5.30.1.127.3.10.1.41".equals(roles.getAssigningAuthority().getUniversalId())) return true;
-    		if ("REP".equals(roles.getId()) && "2.16.756.5.30.1.127.3.10.1.41".equals(roles.getAssigningAuthority().getUniversalId())) return true;
+    		if ("PAT".equals(roles.getId()) && "2.16.756.5.30.1.127.3.10.6".equals(roles.getAssigningAuthority().getUniversalId())) return true;
+    		if ("REP".equals(roles.getId()) && "2.16.756.5.30.1.127.3.10.6".equals(roles.getAssigningAuthority().getUniversalId())) return true;
     	}
     	return false;
     }

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti65/Iti65RequestConverter.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti65/Iti65RequestConverter.java
@@ -1027,7 +1027,7 @@ public class Iti65RequestConverter extends BaseRequestConverter {
 			result.setAuthorPerson(transform((Practitioner) authorObj));
 			for (ContactPoint contactPoint : practitioner.getTelecom()) result.getAuthorTelecom().add(transform(contactPoint));
 			if (authorRole==null) {
-			    authorRole = new Identifiable("HCP", new AssigningAuthority("2.16.756.5.30.1.127.3.10.1.41"));
+			    authorRole = new Identifiable("HCP", new AssigningAuthority("2.16.756.5.30.1.127.3.10.6"));
 			}
 			result.getAuthorRole().add(authorRole);
 			return result;
@@ -1037,7 +1037,7 @@ public class Iti65RequestConverter extends BaseRequestConverter {
 			result.setAuthorPerson(transform(patient));
 			for (ContactPoint contactPoint : patient.getTelecom()) result.getAuthorTelecom().add(transform(contactPoint));
             if (authorRole==null) {
-                authorRole = new Identifiable("PAT", new AssigningAuthority("2.16.756.5.30.1.127.3.10.1.41"));
+                authorRole = new Identifiable("PAT", new AssigningAuthority("2.16.756.5.30.1.127.3.10.6"));
             }
             result.getAuthorRole().add(authorRole);
 			return result;


### PR DESCRIPTION
All codes in the extra metadata attribute `DocumentEntry.originalProviderRole` shall have the coding system OID `2.16.756.5.30.1.127.3.10.6`. 

@staffoleo: FYI 