### PR TITLE
restore broken functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,11 @@
 			<version>${camel-version}</version>
         </dependency>
         <dependency>
+          <groupId>com.sun.xml.messaging.saaj</groupId>
+          <artifactId>saaj-impl</artifactId>
+          <version>3.0.3</version>
+        </dependency>  
+        <dependency>
 	       <groupId>org.apache.cxf</groupId>
 	       <artifactId>cxf-core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <dependency>
           <groupId>com.sun.xml.messaging.saaj</groupId>
           <artifactId>saaj-impl</artifactId>
-          <version>3.0.3</version>
+          <version>1.5.3</version>
         </dependency>  
         <dependency>
 	       <groupId>org.apache.cxf</groupId>

--- a/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/Config.java
@@ -245,17 +245,20 @@ public class Config {
             havingValue = "true",
             matchIfMissing = false)
     public SSLContextParameters getPixSSLContext() throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
-
+        
         KeyStoreParameters ksp = new KeyStoreParameters();
-        // Keystore file may be found at src/main/resources
-        //ksp.setResource(keystore);
-        //ksp.setPassword(keystorePassword);
-
+            
         // https://www.baeldung.com/java-keystore
         KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         log.info("keystore base64 valued: " + (keystoreBase64 != null && !keystoreBase64.trim().isEmpty()));
-        ks.load(ReadCertificateStream(), keystorePassword.toCharArray());
-        ksp.setKeyStore(ks);
+        if (keystoreBase64 != null && !keystoreBase64.trim().isEmpty()) {
+          ks.load(ReadCertificateStream(), keystorePassword.toCharArray());        
+          ksp.setKeyStore(ks);
+        } else {
+          // Keystore file may be found at src/main/resources
+          ksp.setResource(keystore); 
+          ksp.setPassword(keystorePassword);   
+        }
 
         KeyManagersParameters kmp = new KeyManagersParameters();
         kmp.setKeyStore(ksp);
@@ -280,14 +283,18 @@ public class Config {
 
     public SSLContextParameters getAuditSSLContext() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
         KeyStoreParameters ksp = new KeyStoreParameters();
-        // Keystore file may be found at src/main/resources
-        //ksp.setResource(keystore);
-        //ksp.setPassword(keystorePassword);
-
+       
         // https://www.baeldung.com/java-keystore
         KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-        ks.load(ReadCertificateStream(), keystorePassword.toCharArray());
-        ksp.setKeyStore(ks);
+        log.info("keystore base64 valued: " + (keystoreBase64 != null && !keystoreBase64.trim().isEmpty()));
+        if (keystoreBase64 != null && !keystoreBase64.trim().isEmpty()) {
+          ks.load(ReadCertificateStream(), keystorePassword.toCharArray());        
+          ksp.setKeyStore(ks);
+        } else {
+          // Keystore file may be found at src/main/resources
+          ksp.setResource(keystore); 
+          ksp.setPassword(keystorePassword);   
+        }
 
         KeyManagersParameters kmp = new KeyManagersParameters();
         kmp.setKeyStore(ksp);
@@ -348,10 +355,7 @@ public class Config {
         return frb;
     }
 
-    private InputStream ReadCertificateStream () throws FileNotFoundException {
-        if (keystoreBase64 == null || keystoreBase64.trim().isEmpty()){
-            return new FileInputStream(keystore);
-        }
+    private InputStream ReadCertificateStream () throws FileNotFoundException {        
         byte[] decodedBytes = Base64.getDecoder().decode(keystoreBase64);
         return  new ByteArrayInputStream(decodedBytes);
     }


### PR DESCRIPTION
- loading of keystore / truststore (if no base64 keystore was provided) was broken since "upgrades and improvements #141 ". Restored ability to load keystore using resource loader.
- SAML message processing was broken since  "Feature/ipf dependency update #126 ". Manually added missing  "saaj-impl" dependency.