### PR TITLE
Keep the IDP assertion in the assertion route

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fixed an NPE in the assertion route
+
 ## 2024/05/15 v070
 - support for multiple IDP's [128](https://github.com/i4mi/MobileAccessGateway/issues/128)
 - reenable $find-medication-list

--- a/src/main/java/ch/bfh/ti/i4mi/mag/xua/AssertionFromIdpTokenRouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/xua/AssertionFromIdpTokenRouteBuilder.java
@@ -62,7 +62,8 @@ public class AssertionFromIdpTokenRouteBuilder extends RouteBuilder {
 		    .process(Utils.endHttpSession())
 		    .setProperty("oauthrequest").method(TokenRenew.class, "emptyAuthRequest")		    
 		    .bean(AuthRequestConverter.class, "buildAssertionRequestFromIdp")
-			.bean(Iti40RequestGenerator.class, "buildAssertion")			
+			.bean(TokenRenew.class, "keepIdpAssertion")
+			.bean(Iti40RequestGenerator.class, "buildAssertion")
 			.removeHeaders("*", "scope")
 			.setHeader(CxfConstants.OPERATION_NAME,
 			        constant("Issue"))


### PR DESCRIPTION
When implementing the assertion renew, `TokenEndpoint.generateOAuth2TokenResponse()` was updated to include the IDP assertion as refresh token. The `/camel/assertion` route also uses that method to generate the response, but didn't store the IDP assertion for later use.