### PR TITLE
feat: read the TraceId from Header and propagate it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 		<opensaml-version>2.6.6</opensaml-version>
 		<spring-security-saml2-core-version>1.0.10.RELEASE</spring-security-saml2-core-version>
 		<velocity-version>2.3</velocity-version>
+		<spring-cloud.version>2021.0.5</spring-cloud.version>
 
 
 		<start-class>ch.bfh.ti.i4mi.mag.MobileAccessGateway</start-class>
@@ -69,6 +70,14 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<!-- W3C TraceId -->
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>		
 		</dependencies>
 	</dependencyManagement>
 
@@ -150,6 +159,19 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jetty</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlets</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-util</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
 		</dependency>
 
 		<dependency>
@@ -320,6 +342,32 @@
 			<version>${ipf-version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
+		</dependency>
+
+		<!-- W3C TraceId -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-sleuth</artifactId>
+			<version>3.1.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-sleuth-brave</artifactId>
+			<version>3.1.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-logging</artifactId>
+		</dependency>
+
+		<!-- Servlet API -->
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>4.0.1</version>
+			<scope>provided</scope>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -345,16 +345,21 @@
 		</dependency>
 
 		<!-- W3C TraceId -->
+		<!-- Micrometer Tracing -->
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-sleuth</artifactId>
-			<version>3.1.5</version>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+			<version>1.0.0</version>
 		</dependency>
-
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-sleuth-brave</artifactId>
-			<version>3.1.5</version>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-brave</artifactId>
+			<version>2.16.3</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/ch/bfh/ti/i4mi/mag/CustomPropagationFactory.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/CustomPropagationFactory.java
@@ -1,0 +1,73 @@
+package ch.bfh.ti.i4mi.mag;
+
+import brave.propagation.B3Propagation;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CustomPropagationFactory extends Propagation.Factory {
+
+    private static final String TRACE_PARENT = "traceparent";
+    private static final String TRACE_STATE = "tracestate";
+
+    @Override
+    public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
+        return new CustomPropagation<>(B3Propagation.FACTORY.create(keyFactory), keyFactory);
+    }
+
+    static final class CustomPropagation<K> implements Propagation<K> {
+        final Propagation<K> b3;
+        final K traceParentKey, traceStateKey;
+
+        CustomPropagation(Propagation<K> b3, KeyFactory<K> keyFactory) {
+            this.b3 = b3;
+            this.traceParentKey = keyFactory.create(TRACE_PARENT);
+            this.traceStateKey = keyFactory.create(TRACE_STATE);
+        }
+
+        @Override
+        public List<K> keys() {
+            return Arrays.asList(traceParentKey, traceStateKey);
+        }
+
+        @Override
+        public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
+            return b3.injector(setter);
+        }
+
+        @Override
+        public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
+            return new TraceContext.Extractor<C>() {
+                @Override
+                public TraceContextOrSamplingFlags extract(C carrier) {
+                    String traceParent = getter.get(carrier, traceParentKey);
+                    if (traceParent != null) {
+                        return extractFromTraceParent(traceParent);
+                    }
+                    return b3.extractor(getter).extract(carrier);
+                }
+            };
+        }
+
+        private TraceContextOrSamplingFlags extractFromTraceParent(String traceParent) {
+            String[] parts = traceParent.split("-");
+            if (parts.length != 4) {
+                return TraceContextOrSamplingFlags.EMPTY;
+            }
+            long traceIdHigh = Long.parseUnsignedLong(parts[1].substring(0, 16), 16);
+            long traceIdLow = Long.parseUnsignedLong(parts[1].substring(16), 16);
+            long spanId = Long.parseUnsignedLong(parts[2], 16);
+            byte samplingFlags = Byte.parseByte(parts[3], 16);
+
+            return TraceContextOrSamplingFlags.create(TraceContext.newBuilder()
+                    .traceIdHigh(traceIdHigh)
+                    .traceId(traceIdLow)
+                    .spanId(spanId)
+                    .sampled(samplingFlags == 1)
+                    .build());
+        }
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/FilterConfig.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/FilterConfig.java
@@ -3,14 +3,21 @@ package ch.bfh.ti.i4mi.mag;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import io.micrometer.tracing.Tracer;
 
 @Configuration
 public class FilterConfig {
 
+    private final Tracer tracer;
+
+    public FilterConfig(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
     @Bean
     public FilterRegistrationBean<TraceHeaderLoggingFilter> loggingFilter() {
         FilterRegistrationBean<TraceHeaderLoggingFilter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(new TraceHeaderLoggingFilter());
+        registrationBean.setFilter(new TraceHeaderLoggingFilter(tracer));
         registrationBean.addUrlPatterns("/*");
         registrationBean.setOrder(1);
         return registrationBean;

--- a/src/main/java/ch/bfh/ti/i4mi/mag/FilterConfig.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/FilterConfig.java
@@ -1,0 +1,27 @@
+package ch.bfh.ti.i4mi.mag;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<TraceHeaderLoggingFilter> loggingFilter() {
+        FilterRegistrationBean<TraceHeaderLoggingFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new TraceHeaderLoggingFilter());
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setOrder(1);
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<RequestIdFilter> requestIdFilter() {
+        FilterRegistrationBean<RequestIdFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new RequestIdFilter());
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setOrder(2);
+        return registrationBean;
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/LoggingSpanHandler.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/LoggingSpanHandler.java
@@ -1,0 +1,30 @@
+package ch.bfh.ti.i4mi.mag;
+
+import brave.handler.MutableSpan;
+import brave.handler.SpanHandler;
+import brave.propagation.TraceContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggingSpanHandler extends SpanHandler {
+    private static final Logger logger = LoggerFactory.getLogger(LoggingSpanHandler.class);
+
+    @Override
+    public boolean begin(TraceContext context, MutableSpan span, TraceContext parent) {
+        logger.info("Span started: traceId={}, spanId={}, parentId={}",
+                context.traceIdString(),
+                context.spanIdString(),
+                parent != null ? parent.spanIdString() : "none");
+        return true;
+    }
+
+    @Override
+    public boolean end(TraceContext context, MutableSpan span, Cause cause) {
+        logger.info("Span completed: traceId={}, spanId={}, name={}, duration={}ms",
+                context.traceIdString(),
+                context.spanIdString(),
+                span.name(),
+                span.finishTimestamp() - span.startTimestamp());
+        return true;
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/LoggingSpanHandler.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/LoggingSpanHandler.java
@@ -9,22 +9,38 @@ import org.slf4j.LoggerFactory;
 public class LoggingSpanHandler extends SpanHandler {
     private static final Logger logger = LoggerFactory.getLogger(LoggingSpanHandler.class);
 
+    public LoggingSpanHandler() {
+        logger.info("LoggingSpanHandler constructed");
+    }
+
     @Override
     public boolean begin(TraceContext context, MutableSpan span, TraceContext parent) {
-        logger.info("Span started: traceId={}, spanId={}, parentId={}",
-                context.traceIdString(),
-                context.spanIdString(),
-                parent != null ? parent.spanIdString() : "none");
+        logger.info("begin method called");
+        if (context != null) {
+            logger.info("Span started: traceId={}, spanId={}, parentId={}, name={}",
+                    context.traceIdString(),
+                    context.spanIdString(),
+                    parent != null ? parent.spanIdString() : "none",
+                    span != null ? span.name() : "null");
+        } else {
+            logger.info("Span started: context is null");
+        }
         return true;
     }
 
     @Override
     public boolean end(TraceContext context, MutableSpan span, Cause cause) {
-        logger.info("Span completed: traceId={}, spanId={}, name={}, duration={}ms",
-                context.traceIdString(),
-                context.spanIdString(),
-                span.name(),
-                span.finishTimestamp() - span.startTimestamp());
+        logger.info("end method called");
+        if (context != null && span != null) {
+            logger.info("Span completed: traceId={}, spanId={}, name={}, duration={}ms, tags={}",
+                    context.traceIdString(),
+                    context.spanIdString(),
+                    span.name(),
+                    span.finishTimestamp() - span.startTimestamp(),
+                    span.tags());
+        } else {
+            logger.info("Span completed: context or span is null");
+        }
         return true;
     }
 }

--- a/src/main/java/ch/bfh/ti/i4mi/mag/MobileAccessGateway.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/MobileAccessGateway.java
@@ -31,7 +31,6 @@ import javax.validation.spi.ValidationProvider;
  *
  * @author Oliver Egger
  */
-@SpringBootApplication(exclude = {org.springframework.cloud.sleuth.autoconfig.brave.BraveAutoConfiguration.class})
 @Slf4j
 @ComponentScan(basePackages={"ch.bfh.ti.i4mi.mag","org.openehealth.ipf","org.springframework.security.saml"})
 // without it does not work directly with mvn and current snapshot, when running the Pixm query an error is returned   "resourceType": "OperationOutcome", "issue": [ { "severity": "error", "code": "processing", "diagnostics": "Unknown resource type 'Patient' - Server knows how to handle: [StructureDefinition, OperationDefinition]" } ]

--- a/src/main/java/ch/bfh/ti/i4mi/mag/MobileAccessGateway.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/MobileAccessGateway.java
@@ -31,9 +31,9 @@ import javax.validation.spi.ValidationProvider;
  *
  * @author Oliver Egger
  */
-@SpringBootApplication
+@SpringBootApplication(exclude = {org.springframework.cloud.sleuth.autoconfig.brave.BraveAutoConfiguration.class})
 @Slf4j
-@ComponentScan(basePackages={"ch.bfh.ti.i4mi.mag","org.openehealth.ipf","org.springframework.security.saml"})	
+@ComponentScan(basePackages={"ch.bfh.ti.i4mi.mag","org.openehealth.ipf","org.springframework.security.saml"})
 // without it does not work directly with mvn and current snapshot, when running the Pixm query an error is returned   "resourceType": "OperationOutcome", "issue": [ { "severity": "error", "code": "processing", "diagnostics": "Unknown resource type 'Patient' - Server knows how to handle: [StructureDefinition, OperationDefinition]" } ]
 // it looks like the META-INF directory is not correct configured that is copied to the output, if it is added in eclipse as on open project to java/main/resources it works without above line 
 @EnableAutoConfiguration

--- a/src/main/java/ch/bfh/ti/i4mi/mag/RequestIdFilter.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/RequestIdFilter.java
@@ -1,0 +1,31 @@
+package ch.bfh.ti.i4mi.mag;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+
+public class RequestIdFilter extends OncePerRequestFilter {
+    private static final Logger logger = LoggerFactory.getLogger(RequestIdFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String requestId = UUID.randomUUID().toString();
+        MDC.put("requestId", requestId);
+        try {
+            logger.info("Processing request: {}", requestId);
+            filterChain.doFilter(request, response);
+        } finally {
+            logger.info("Completed request: {}", requestId);
+            MDC.remove("requestId");
+        }
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/TraceHeaderLoggingFilter.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/TraceHeaderLoggingFilter.java
@@ -1,22 +1,25 @@
 package ch.bfh.ti.i4mi.mag;
 
+import io.micrometer.tracing.Tracer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 
 @Component
 public class TraceHeaderLoggingFilter implements Filter {
     private static final Logger logger = LoggerFactory.getLogger(TraceHeaderLoggingFilter.class);
+
+    private final Tracer tracer;
+
+    public TraceHeaderLoggingFilter(Tracer tracer) {
+        this.tracer = tracer;
+    }
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
@@ -26,25 +29,17 @@ public class TraceHeaderLoggingFilter implements Filter {
         String traceparent = request.getHeader("traceparent");
         String tracestate = request.getHeader("tracestate");
         String b3 = request.getHeader("b3");
-        String b3TraceId = request.getHeader("X-B3-TraceId");
-        String b3SpanId = request.getHeader("X-B3-SpanId");
 
-        // Log the headers in a structured format
-        logger.info("Trace headers: traceparent={}, tracestate={}, b3={}, X-B3-TraceId={}, X-B3-SpanId={}",
-                traceparent, tracestate, b3, b3TraceId, b3SpanId);
+        logger.info("Trace headers: traceparent={}, tracestate={}, b3={}", traceparent, tracestate, b3);
 
-        // Add the headers to MDC for logging
         MDC.put("traceparent", traceparent);
         MDC.put("tracestate", tracestate);
         MDC.put("b3", b3);
-        MDC.put("X-B3-TraceId", b3TraceId);
-        MDC.put("X-B3-SpanId", b3SpanId);
 
         try {
             filterChain.doFilter(request, response);
         } finally {
-            // Clean up MDC
-            MDC.clear();  // This removes all MDC entries
+            MDC.clear();
         }
     }
 }

--- a/src/main/java/ch/bfh/ti/i4mi/mag/TraceHeaderLoggingFilter.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/TraceHeaderLoggingFilter.java
@@ -1,0 +1,50 @@
+package ch.bfh.ti.i4mi.mag;
+
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+@Component
+public class TraceHeaderLoggingFilter implements Filter {
+    private static final Logger logger = LoggerFactory.getLogger(TraceHeaderLoggingFilter.class);
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        String traceparent = request.getHeader("traceparent");
+        String tracestate = request.getHeader("tracestate");
+        String b3 = request.getHeader("b3");
+        String b3TraceId = request.getHeader("X-B3-TraceId");
+        String b3SpanId = request.getHeader("X-B3-SpanId");
+
+        // Log the headers in a structured format
+        logger.info("Trace headers: traceparent={}, tracestate={}, b3={}, X-B3-TraceId={}, X-B3-SpanId={}",
+                traceparent, tracestate, b3, b3TraceId, b3SpanId);
+
+        // Add the headers to MDC for logging
+        MDC.put("traceparent", traceparent);
+        MDC.put("tracestate", tracestate);
+        MDC.put("b3", b3);
+        MDC.put("X-B3-TraceId", b3TraceId);
+        MDC.put("X-B3-SpanId", b3SpanId);
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            // Clean up MDC
+            MDC.clear();  // This removes all MDC entries
+        }
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/TracingConfiguration.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/TracingConfiguration.java
@@ -1,30 +1,47 @@
 package ch.bfh.ti.i4mi.mag;
 
 import brave.Tracing;
-import brave.propagation.B3Propagation;
-import brave.propagation.CurrentTraceContext;
-import brave.propagation.Propagation;
+import brave.handler.SpanHandler;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.brave.bridge.BraveBaggageManager;
+import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
+import io.micrometer.tracing.brave.bridge.BraveTracer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Configuration
 public class TracingConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(TracingConfiguration.class);
 
     @Bean
-    public Tracing tracing() {
+    public Tracer tracer(Tracing braveTracing) {
+        logger.info("Creating BraveTracer");
+        return new BraveTracer(braveTracing.tracer(),
+                new BraveCurrentTraceContext(braveTracing.currentTraceContext()),
+                new BraveBaggageManager());
+    }
+
+    @Bean
+    public Tracing braveTracing(SpanHandler spanHandler) {
+        logger.info("Creating Tracing with SpanHandler: {}", spanHandler.getClass().getName());
         return Tracing.newBuilder()
-                .sampler(Sampler.ALWAYS_SAMPLE)
-                .propagationFactory(new CustomPropagationFactory())
-                .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder().build())
+                .localServiceName("mobile-access-gateway")
                 .supportsJoin(false)
                 .traceId128Bit(true)
+                .sampler(Sampler.ALWAYS_SAMPLE)
+                .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder().build())
+                .propagationFactory(new CustomPropagationFactory())
+                .addSpanHandler(spanHandler)
                 .build();
     }
 
     @Bean
-    public brave.handler.SpanHandler loggingSpanHandler() {
+    public SpanHandler loggingSpanHandler() {
+        logger.info("Creating LoggingSpanHandler");
         return new LoggingSpanHandler();
     }
 }

--- a/src/main/java/ch/bfh/ti/i4mi/mag/TracingConfiguration.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/TracingConfiguration.java
@@ -1,0 +1,30 @@
+package ch.bfh.ti.i4mi.mag;
+
+import brave.Tracing;
+import brave.propagation.B3Propagation;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.Propagation;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.sampler.Sampler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TracingConfiguration {
+
+    @Bean
+    public Tracing tracing() {
+        return Tracing.newBuilder()
+                .sampler(Sampler.ALWAYS_SAMPLE)
+                .propagationFactory(new CustomPropagationFactory())
+                .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder().build())
+                .supportsJoin(false)
+                .traceId128Bit(true)
+                .build();
+    }
+
+    @Bean
+    public brave.handler.SpanHandler loggingSpanHandler() {
+        return new LoggingSpanHandler();
+    }
+}

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti67/Iti67RouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti67/Iti67RouteBuilder.java
@@ -85,45 +85,44 @@ class Iti67RouteBuilder extends RouteBuilder {
         final String metadataQueryEndpoint  = createEndpointUri("xds-iti18", this.config.getIti18HostUrl());
         final String metadataUpdateEndpoint = createEndpointUri("xds-iti57", this.config.getIti57HostUrl());
 
-        from("mhd-iti67-v401:translation?audit=true&auditContext=#myAuditContext")
-                .routeId("mdh-documentreference-adapter")
+        from("mhd-iti67-v401:translation?audit=true&auditContext=#myAuditContext").routeId("mdh-documentreference-adapter")
                 .errorHandler(noErrorHandler())
                 .process(AuthTokenConverter.addWsHeader())
                 .choice()
-                .when(header(Constants.FHIR_REQUEST_PARAMETERS).isNotNull())
-                .bean(Utils.class,"searchParameterToBody")
-                .bean(Iti67RequestConverter.class)
-                .to(metadataQueryEndpoint)
-                .process(translateToFhir(iti67ResponseConverter, QueryResponse.class))
+                    .when(header(Constants.FHIR_REQUEST_PARAMETERS).isNotNull())
+                    .bean(Utils.class,"searchParameterToBody")
+                    .bean(Iti67RequestConverter.class)
+                    .to(metadataQueryEndpoint)
+                    .process(translateToFhir(iti67ResponseConverter, QueryResponse.class))
                 .when(PredicateBuilder.and(header("FhirHttpUri").isNotNull(), header("FhirHttpMethod").isEqualTo("GET")))
-                .bean(IdRequestConverter.class)
-                .to(metadataQueryEndpoint)
-                .process(translateToFhir(iti67ResponseConverter, QueryResponse.class))
+                    .bean(IdRequestConverter.class)
+                    .to(metadataQueryEndpoint)
+                    .process(translateToFhir(iti67ResponseConverter, QueryResponse.class))
                 .when(PredicateBuilder.and(header("FhirHttpUri").isNotNull(), header("FhirHttpMethod").isEqualTo("PUT")))
-                .process(exchange -> {
-                    DocumentReference documentReference = exchange.getIn().getMandatoryBody(DocumentReference.class);
-                    SubmitObjectsRequest submitObjectsRequest = iti67RequestUpdateConverter.createMetadataUpdateRequest(documentReference);
-                    exchange.getMessage().setBody(submitObjectsRequest);
-                })
-                .to(metadataUpdateEndpoint)
-                .process(translateToFhir(iti67FromIti57ResponseConverter, Response.class))
+                    .process(exchange -> {
+                        DocumentReference documentReference = exchange.getIn().getMandatoryBody(DocumentReference.class);
+                        SubmitObjectsRequest submitObjectsRequest = iti67RequestUpdateConverter.createMetadataUpdateRequest(documentReference);
+                        exchange.getMessage().setBody(submitObjectsRequest);
+                    })
+                    .to(metadataUpdateEndpoint)
+                    .process(translateToFhir(iti67FromIti57ResponseConverter, Response.class))
                 .when(PredicateBuilder.and(header("FhirHttpUri").isNotNull(), header("FhirHttpMethod").isEqualTo("DELETE")))
-                .process(exchange -> {
-                    exchange.setProperty("DOCUMENT_ENTRY_LOGICAL_ID", IdRequestConverter.extractId(exchange.getIn().getHeader("FhirHttpUri", String.class)));
-                })
-                .bean(IdRequestConverter.class)
-                .to(metadataQueryEndpoint)
-                .process(exchange -> {
-                    QueryResponse queryResponse = exchange.getIn().getMandatoryBody(QueryResponse.class);
-                    if (queryResponse.getStatus() != Status.SUCCESS) {
-                        iti67FromIti57ResponseConverter.processError(queryResponse);
-                    }
-                    if (queryResponse.getDocumentEntries().isEmpty()) {
-                        throw new ResourceNotFoundException(exchange.getProperty("DOCUMENT_ENTRY_LOGICAL_ID", String.class));
-                    }
-                    if (queryResponse.getDocumentEntries().size() > 1) {
-                        throw new InternalErrorException("Expected at most one Document Entry, got " + queryResponse.getDocumentEntries().size());
-                    }
+                    .process(exchange -> {
+                        exchange.setProperty("DOCUMENT_ENTRY_LOGICAL_ID", IdRequestConverter.extractId(exchange.getIn().getHeader("FhirHttpUri", String.class)));
+                    })
+                    .bean(IdRequestConverter.class)
+                    .to(metadataQueryEndpoint)
+                    .process(exchange -> {
+                        QueryResponse queryResponse = exchange.getIn().getMandatoryBody(QueryResponse.class);
+                        if (queryResponse.getStatus() != Status.SUCCESS) {
+                            iti67FromIti57ResponseConverter.processError(queryResponse);
+                        }
+                        if (queryResponse.getDocumentEntries().isEmpty()) {
+                            throw new ResourceNotFoundException(exchange.getProperty("DOCUMENT_ENTRY_LOGICAL_ID", String.class));
+                        }
+                        if (queryResponse.getDocumentEntries().size() > 1) {
+                            throw new InternalErrorException("Expected at most one Document Entry, got " + queryResponse.getDocumentEntries().size());
+                        }
 
                     DocumentEntry documentEntry = queryResponse.getDocumentEntries().get(0);
                     if (documentEntry.getExtraMetadata() == null) {

--- a/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti67/Iti67RouteBuilder.java
+++ b/src/main/java/ch/bfh/ti/i4mi/mag/mhd/iti67/Iti67RouteBuilder.java
@@ -85,74 +85,66 @@ class Iti67RouteBuilder extends RouteBuilder {
         final String metadataQueryEndpoint  = createEndpointUri("xds-iti18", this.config.getIti18HostUrl());
         final String metadataUpdateEndpoint = createEndpointUri("xds-iti57", this.config.getIti57HostUrl());
 
-        from("mhd-iti67-v401:translation?audit=true&auditContext=#myAuditContext").routeId("mdh-documentreference-adapter")
-                // pass back errors to the endpoint
+        from("mhd-iti67-v401:translation?audit=true&auditContext=#myAuditContext")
+                .routeId("mdh-documentreference-adapter")
                 .errorHandler(noErrorHandler())
                 .process(AuthTokenConverter.addWsHeader())
                 .choice()
-                  .when(header(Constants.FHIR_REQUEST_PARAMETERS).isNotNull())
-                    .bean(Utils.class,"searchParameterToBody")
-                    .bean(Iti67RequestConverter.class)
-                    .to(metadataQueryEndpoint)
-                    .process(translateToFhir(iti67ResponseConverter, QueryResponse.class))
-                    .endChoice()
-                  .when(PredicateBuilder.and(header("FhirHttpUri").isNotNull(),header("FhirHttpMethod").isEqualTo("GET")))
-                    .bean(IdRequestConverter.class)
-                    .to(metadataQueryEndpoint)
-                    .process(translateToFhir(iti67ResponseConverter, QueryResponse.class))
-                    .endChoice()
-                  .when(PredicateBuilder.and(header("FhirHttpUri").isNotNull(),header("FhirHttpMethod").isEqualTo("PUT")))
-                    .process(exchange -> {
-                        DocumentReference documentReference = exchange.getIn().getMandatoryBody(DocumentReference.class);
-                        SubmitObjectsRequest submitObjectsRequest = iti67RequestUpdateConverter.createMetadataUpdateRequest(documentReference);
-                        exchange.getMessage().setBody(submitObjectsRequest);
-                    })
-                    .to(metadataUpdateEndpoint)
-                    .process(translateToFhir(iti67FromIti57ResponseConverter, Response.class))
-                    .endChoice()
-                .when(PredicateBuilder.and(header("FhirHttpUri").isNotNull(),header("FhirHttpMethod").isEqualTo("DELETE")))
-                    .process(exchange -> {
-                        exchange.setProperty("DOCUMENT_ENTRY_LOGICAL_ID", IdRequestConverter.extractId(exchange.getIn().getHeader("FhirHttpUri", String.class)));
-                    })
-                    .bean(IdRequestConverter.class)
-                    .to(metadataQueryEndpoint)
-                    .process(exchange -> {
-                        QueryResponse queryResponse = exchange.getIn().getMandatoryBody(QueryResponse.class);
-                        if (queryResponse.getStatus() != Status.SUCCESS) {
-                            iti67FromIti57ResponseConverter.processError(queryResponse);
-                        }
-                        if (queryResponse.getDocumentEntries().isEmpty()) {
-                            throw new ResourceNotFoundException(exchange.getProperty("DOCUMENT_ENTRY_LOGICAL_ID", String.class));
-                        }
-                        if (queryResponse.getDocumentEntries().size() > 1) {
-                            throw new InternalErrorException("Expected at most one Document Entry, got " + queryResponse.getDocumentEntries().size());
-                        }
+                .when(header(Constants.FHIR_REQUEST_PARAMETERS).isNotNull())
+                .bean(Utils.class,"searchParameterToBody")
+                .bean(Iti67RequestConverter.class)
+                .to(metadataQueryEndpoint)
+                .process(translateToFhir(iti67ResponseConverter, QueryResponse.class))
+                .when(PredicateBuilder.and(header("FhirHttpUri").isNotNull(), header("FhirHttpMethod").isEqualTo("GET")))
+                .bean(IdRequestConverter.class)
+                .to(metadataQueryEndpoint)
+                .process(translateToFhir(iti67ResponseConverter, QueryResponse.class))
+                .when(PredicateBuilder.and(header("FhirHttpUri").isNotNull(), header("FhirHttpMethod").isEqualTo("PUT")))
+                .process(exchange -> {
+                    DocumentReference documentReference = exchange.getIn().getMandatoryBody(DocumentReference.class);
+                    SubmitObjectsRequest submitObjectsRequest = iti67RequestUpdateConverter.createMetadataUpdateRequest(documentReference);
+                    exchange.getMessage().setBody(submitObjectsRequest);
+                })
+                .to(metadataUpdateEndpoint)
+                .process(translateToFhir(iti67FromIti57ResponseConverter, Response.class))
+                .when(PredicateBuilder.and(header("FhirHttpUri").isNotNull(), header("FhirHttpMethod").isEqualTo("DELETE")))
+                .process(exchange -> {
+                    exchange.setProperty("DOCUMENT_ENTRY_LOGICAL_ID", IdRequestConverter.extractId(exchange.getIn().getHeader("FhirHttpUri", String.class)));
+                })
+                .bean(IdRequestConverter.class)
+                .to(metadataQueryEndpoint)
+                .process(exchange -> {
+                    QueryResponse queryResponse = exchange.getIn().getMandatoryBody(QueryResponse.class);
+                    if (queryResponse.getStatus() != Status.SUCCESS) {
+                        iti67FromIti57ResponseConverter.processError(queryResponse);
+                    }
+                    if (queryResponse.getDocumentEntries().isEmpty()) {
+                        throw new ResourceNotFoundException(exchange.getProperty("DOCUMENT_ENTRY_LOGICAL_ID", String.class));
+                    }
+                    if (queryResponse.getDocumentEntries().size() > 1) {
+                        throw new InternalErrorException("Expected at most one Document Entry, got " + queryResponse.getDocumentEntries().size());
+                    }
 
-                        DocumentEntry documentEntry = queryResponse.getDocumentEntries().get(0);
-                        if (documentEntry.getExtraMetadata() == null) {
-                            documentEntry.setExtraMetadata(new HashMap<>());
-                        }
-                        documentEntry.getExtraMetadata().put(MagConstants.XdsExtraMetadataSlotNames.CH_DELETION_STATUS, List.of(MagConstants.DeletionStatuses.REQUESTED));
-                        if (documentEntry.getLogicalUuid() == null) {
-                            documentEntry.setLogicalUuid(documentEntry.getEntryUuid());
-                        }
-                        documentEntry.assignEntryUuid();
-                        if (documentEntry.getVersion() == null) {
-                            documentEntry.setVersion(new Version("1"));
-                        }
+                    DocumentEntry documentEntry = queryResponse.getDocumentEntries().get(0);
+                    if (documentEntry.getExtraMetadata() == null) {
+                        documentEntry.setExtraMetadata(new HashMap<>());
+                    }
+                    documentEntry.getExtraMetadata().put(MagConstants.XdsExtraMetadataSlotNames.CH_DELETION_STATUS, List.of(MagConstants.DeletionStatuses.REQUESTED));
+                    if (documentEntry.getLogicalUuid() == null) {
+                        documentEntry.setLogicalUuid(documentEntry.getEntryUuid());
+                    }
+                    documentEntry.assignEntryUuid();
+                    if (documentEntry.getVersion() == null) {
+                        documentEntry.setVersion(new Version("1"));
+                    }
 
-                        SubmissionSet submissionSet = iti67RequestUpdateConverter.createSubmissionSet();
-                        SubmitObjectsRequest updateRequest = iti67RequestUpdateConverter.createMetadataUpdateRequest(submissionSet, documentEntry);
-                        exchange.getMessage().setBody(updateRequest);
-                        log.info("Prepared document metadata update request");
-                    })
-                    .choice()
-                        .when(exchange -> exchange.getIn().getBody() instanceof SubmitObjectsRequest)
-                            .to(metadataUpdateEndpoint)
-                            .process(translateToFhir(new Iti67FromIti57ResponseConverter(config), Response.class))
-                            .endChoice()
-                        .end()
-                    .endChoice()
+                    SubmissionSet submissionSet = iti67RequestUpdateConverter.createSubmissionSet();
+                    SubmitObjectsRequest updateRequest = iti67RequestUpdateConverter.createMetadataUpdateRequest(submissionSet, documentEntry);
+                    exchange.getMessage().setBody(updateRequest);
+                    log.info("Prepared document metadata update request");
+                })
+                .to(metadataUpdateEndpoint)
+                .process(translateToFhir(new Iti67FromIti57ResponseConverter(config), Response.class))
                 .end();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,6 +109,9 @@ logging:
     org.springframework.cloud.sleuth: debug
     org.springframework.web: debug
     org.springframework.http: debug
+    io.micrometer.tracing: debug
+    ch.bfh.ti.i4mi.mag.LoggingSpanHandler: debug
+    brave: debug
   appender:
     console:
       enabled: true
@@ -127,23 +130,16 @@ spring:
   # W3C Trace-Id and related recommendations
   # https://www.w3.org/TR/trace-context/
   sleuth:
-    enabled: true
-    propagation:
-      type: CUSTOM
-    sampler:
+    enabled: false
+  tracing:
+    sampling:
       probability: 1.0
-      remote-fields:
-        - tracestate
-    trace-id128: true
-    supportsJoin: false
-    web:
-      client:
-        enabled: true
-      servlet:
-        enabled: true
-      filter-order: 0
-    zipkin:
-      enabled: false
+      baggage:
+        correlation:
+          enabled: true
+      propagation:
+        type: W3C
+    enabled: true
   log:
     slf4j:
       whitelisted-mdc-keys:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,9 +91,30 @@ server:
   error:
     whitelabel:
       enabled: false
+	jetty:
+    	accesslog:
+      		enabled: true
+      		use-slf4j: true
+
 logging:
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{traceId}/%X{spanId}] [%X{requestId}] %-5level [%thread] %logger{36} - %X{traceparent} - %X{tracestate} - %msg%n"
   level:
     root: info
+    org.springframework.security: debug
+    org.openehealth.ipf.commons.ihe: debug  # Ensure the IPF logs are at the desired level
+    ch.bfh.ti.i4mi: debug
+    org.eclipse.jetty.server.RequestLog: debug
+    org.springframework.web.servlet.DispatcherServlet: debug
+    org.springframework.cloud.sleuth: debug
+    org.springframework.web: debug
+    org.springframework.http: debug
+  appender:
+    console:
+      enabled: true
+      immediateFlush: true
+    file:
+      enabled: false
 
 camel:
   springboot:
@@ -103,9 +124,29 @@ camel:
 spring:
   application:
     name: mobile-access-gateway
-
-management:
-  endpoint:
-    health:
-      probes:
+  # W3C Trace-Id and related recommendations
+  # https://www.w3.org/TR/trace-context/
+  sleuth:
+    enabled: true
+    propagation:
+      type: CUSTOM
+    sampler:
+      probability: 1.0
+      remote-fields:
+        - tracestate
+    trace-id128: true
+    supportsJoin: false
+    web:
+      client:
         enabled: true
+      servlet:
+        enabled: true
+      filter-order: 0
+    zipkin:
+      enabled: false
+  log:
+    slf4j:
+      whitelisted-mdc-keys:
+        - traceId
+        - spanId
+        - parentId

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,10 +91,10 @@ server:
   error:
     whitelabel:
       enabled: false
-	jetty:
-    	accesslog:
-      		enabled: true
-      		use-slf4j: true
+    jetty:
+        accesslog:
+            enabled: true
+            use-slf4j: true
 
 logging:
   pattern:


### PR DESCRIPTION
The goal of this PR is to add the capability to use interpret the W3C headers as specified here: https://www.w3.org/TR/trace-context/ and at the moment we dump them in the log, that according to the application.yml is sending them to the console.
Please note I might have added more than needed in the application.yml in particular regarding the health endpoints, if that is the case I will amend it.